### PR TITLE
Fix Data Binding template

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yo android-architecture
 ? Choose architecture from https://github.com/googlesamples/android-architecture? (Use arrow keys)
 ❯ todo-mvp - Basic Model-View-Presenter architecture.
   todo-mvp-loaders - Based on todo-mvp, fetches data using Loaders.
-  todo-mvp-databinding - Based on todo-mvp, uses the Data Binding Library.
+  todo-databinding - Based on todo-mvp, uses the Data Binding Library.
   todo-mvp-clean - Based on todo-mvp, uses concepts from Clean Architecture.
   todo-mvp-dagger - Based on todo-mvp, uses Dagger2 for Dependency Injection.
   todo-mvp-rxjava - Based on todo-mvp, uses RxJava for concurrency and data layer abstraction.

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -44,8 +44,8 @@ module.exports = Generator.extend({
         name: 'todo-mvp-loaders - Based on todo-mvp, fetches data using Loaders.',
         value: 'todo-mvp-loaders'
       }, {
-        name: 'todo-mvp-databinding - Based on todo-mvp, uses the Data Binding Library.',
-        value: 'todo-mvp-databinding'
+        name: 'todo-databinding - Based on todo-mvp, uses the Data Binding Library.',
+        value: 'todo-databinding'
       }, {
         name: 'todo-mvp-clean - Based on todo-mvp, uses concepts from Clean Architecture.',
         value: 'todo-mvp-clean'


### PR DESCRIPTION
Changing **todo-mvp-databinding** to **todo-databinding**

Data Binding template was broken because the original name from google samples is todo-databinding but it was being called todo-mvp-databinding.